### PR TITLE
Controller

### DIFF
--- a/controller/.dockerignore
+++ b/controller/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.idea
+build
+*.iml

--- a/controller/.gitignore
+++ b/controller/.gitignore
@@ -45,3 +45,5 @@ node_modules
 .dist/
 .pem
 .env
+db-config.yaml
+db-secret.yaml

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,14 +1,14 @@
-# 1단계: Gradle 빌드
+# 1단계: Gradle 빌드 (JAR 생성)
 FROM gradle:8.4-jdk21-alpine AS builder
 WORKDIR /app
-COPY . .
-RUN gradle build --no-daemon
+COPY --chown=gradle:gradle . .
+RUN gradle bootJar --no-daemon
 
-# 2단계: 실행 이미지 생성
+# 2단계: JAR만 실행하는 경량 이미지
 FROM eclipse-temurin:21-jdk-alpine
 WORKDIR /app
 
-# 빌드된 JAR 복사 (파일명 정확히 맞춰야 함)
+# 빌드된 JAR 복사 (정확한 이름으로 변경해야 함)
 COPY --from=builder /app/build/libs/controller-0.0.1-SNAPSHOT.jar app.jar
 
 EXPOSE 8080

--- a/controller/build.gradle
+++ b/controller/build.gradle
@@ -25,12 +25,11 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework:spring-messaging'
+    implementation 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'org.projectlombok:lombok'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-
-    runtimeOnly 'com.mysql:mysql-connector-j'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/controller/docker-compose.yml
+++ b/controller/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+
+services:
+  backend:
+    container_name: prism-backend
+    image: prism-backend
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/controller/kubernetes/db-config.yaml
+++ b/controller/kubernetes/db-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-config
+  namespace: controller
+data:
+  DB_DRIVER_CLASS_NAME: "org.mariadb.jdbc.Driver"
+  DB_URL: "jdbc:mariadb://172.30.29.105:3306/cctv_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8"
+  DB_USERNAME: "root"

--- a/controller/kubernetes/db-secret.yaml
+++ b/controller/kubernetes/db-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-secret
+  namespace: controller
+type: Opaque
+stringData:
+  DB_PASSWORD: "choi201302133!"

--- a/controller/kubernetes/deployment.yaml
+++ b/controller/kubernetes/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: prism-backend
           image: suggiss/prism-backend:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
           env:

--- a/controller/kubernetes/ingress.yaml
+++ b/controller/kubernetes/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prism-backend          # 기존 이름 유지
+  namespace: controller        # 백엔드가 있는 NS
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx      # ← 확인된 클래스명
+  tls:
+    - hosts:
+        - backend.cccr4.com
+      secretName: backend-cccr4-tls
+  rules:
+    - host: backend.cccr4.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prism-backend
+                port:
+                  number: 80

--- a/controller/kubernetes/service.yaml
+++ b/controller/kubernetes/service.yaml
@@ -11,4 +11,21 @@ spec:
   ports:
     - port: 80
       targetPort: 8080
-  type: ClusterIP
+      nodePort: 30001
+  type: NodePort
+
+
+#apiVersion: v1
+#kind: Service
+#metadata:
+#  name: prism-backend
+#  namespace: controller
+#  labels:
+#    app: prism-backend
+#spec:
+#  selector:
+#    app: prism-backend
+#  ports:
+#    - port: 80
+#      targetPort: 8080
+#  type: ClusterIP

--- a/controller/src/main/java/prism/config/config/WebConfig.java
+++ b/controller/src/main/java/prism/config/config/WebConfig.java
@@ -9,9 +9,14 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")
-                .allowedMethods("*")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "http://frontend.cccr4.com",   // ← 추가
+                        "https://frontend.cccr4.com"   // 기존
+                )
+                .allowedMethods("GET","POST","PUT","DELETE","OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);
     }
+
 }


### PR DESCRIPTION
feat(k8s,frontend): 동일 오리진 /api 프록시로 프론트↔백엔드 연동 안정화

- front 네임스페이스에 backend-external(Service) 추가
- frontend-api Ingress로 /api → prism-backend 프록시 및 리라이트
- 프론트 fetch 베이스를 상대경로(/api)로 통일, 하드코딩 URL 제거
- 정적 Ingress의 rewrite-target 제거로 번들 로딩 이슈 방지